### PR TITLE
[CHNL-19855] Updating Deeplink domain + removing ios navigate on receive

### DIFF
--- a/example/app.json
+++ b/example/app.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": "myapp",
+    "scheme": "expoexample",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": false,
     "ios": {

--- a/example/app/_layout.tsx
+++ b/example/app/_layout.tsx
@@ -53,7 +53,6 @@ export default function AppLayout() {
         }
       }, null, 2));
 
-      handleDeeplink(notification);
     });
 
     // Background/Quit notification listener


### PR DESCRIPTION
- changing from the default 'myapp' to 'expoexample'
- accidentally had deeplinking on foreground pushes, which lead iOS to mistakenly navigate on push receive

Tested logic for both forms and pushes on both platforms, here's a lil demo

https://github.com/user-attachments/assets/1c00aa27-8fa3-4a06-a47d-f321ba3cbb5c

