### PR TITLE
Modify npm run reset-all script

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -8,7 +8,7 @@
     "ios": "expo run:ios",
     "web": "expo start --web",
     "test": "jest --watchAll",
-    "reset-all": "rm -rf node_modules package-lock.json && npm install && cd .. && rm -rf node_modules package-lock.json && npm install",
+    "reset-all": "cd .. && rm -rf node_modules package-lock.json && npm install && cd example && rm -rf node_modules package-lock.json && npm install",
     "clean-android": "cd .. && npm run build && cd example && rm -rf android && npx expo prebuild --clean --platform android && npx expo run:android",
     "clean-ios": "cd .. && npm run build && cd example && rm -rf ios && npx expo prebuild --clean --platform ios && npx expo run:ios"
   },


### PR DESCRIPTION
Changes in https://github.com/klaviyo/klaviyo-expo-plugin/pull/11 make it so we should run `npm install` in the root/parent dir first before `npm install` in the `example/` dir