### PR TITLE
iOS Setup -- fix NSE file path and Podfile use_frameworks

### DIFF
--- a/plugin/withKlaviyoIos.ts
+++ b/plugin/withKlaviyoIos.ts
@@ -161,14 +161,27 @@ const withKlaviyoPodfile: ConfigPlugin<KlaviyoPluginIosProps> = (config) => {
     'ios',
     async config => {
       const iosRoot = path.join(config.modRequest.projectRoot, "ios");
-      const podInsertion = `
+      try {
+        const podfile = await FileManager.readFile(`${iosRoot}/Podfile`);
+        // Check for both standard and linkage-specific use_frameworks!
+        const usesFrameworks = podfile.includes('use_frameworks!');
+        const usesFrameworksWithLinkage = podfile.includes('use_frameworks! :linkage');
+        
+        // Extract the linkage type if it exists
+        let linkageType = '';
+        if (usesFrameworksWithLinkage) {
+          const linkageMatch = podfile.match(/use_frameworks!\s*:linkage\s*=>\s*([^,\n]+)/);
+          if (linkageMatch) {
+            linkageType = linkageMatch[1];
+          }
+        }
+        
+        const podInsertion = `
   target 'NotificationServiceExtension' do
-    use_frameworks!
+    ${usesFrameworks ? `use_frameworks!${linkageType ? ` :linkage => ${linkageType}` : ''}` : ''}
     pod 'KlaviyoSwiftExtension'
   end
   `;
-      try {
-        const podfile = await FileManager.readFile(`${iosRoot}/Podfile`);
         if (!podfile.includes("pod 'KlaviyoSwiftExtension'")) {
           const updatedPodfile = `${podfile}\n${podInsertion}`;
           await FileManager.writeFile(`${iosRoot}/Podfile`, updatedPodfile);


### PR DESCRIPTION
While trying to implement our plugin into other apps, we needed to be more explicit with the file path to read from for the NSE setup as well as ensure our podfile addition matches the parent app target's `use_frameworks` -- this now works with both our example app as well as another test app