### PR TITLE
Add all configurable props to example app.json

### DIFF
--- a/example/app.json
+++ b/example/app.json
@@ -46,7 +46,11 @@
             "notificationColor": "#FF0000"
           },
           "ios": {
-            "badgeAutoclearing": true
+            "badgeAutoclearing": true,
+            "codeSigningStyle": "Automatic",
+            "projectVersion": "1",
+            "marketingVersion": "1.0",
+            "swiftVersion": "5.0"
           }
         }
       ]


### PR DESCRIPTION
Just to clearly show all the configurable options (even if they're just the default values) -- like Android has.