### PR TITLE
[CHNL-21879] Remove Adding Klaviyo Push Service to Android Manifest

### DIFF
--- a/plugin/withKlaviyoAndroid.ts
+++ b/plugin/withKlaviyoAndroid.ts
@@ -41,33 +41,6 @@ const withAndroidManifestModifications: ConfigPlugin<KlaviyoPluginAndroidProps> 
         'android:value': logLevel.toString()
       }
     });
-
-    // Add KlaviyoPushService to the manifest
-    if (!application.service) {
-      application.service = [];
-    }
-
-    const pushServiceIndex = application.service.findIndex(
-      (item: any) => item.$['android:name'] === 'com.klaviyo.pushFcm.KlaviyoPushService'
-    );
-
-    if (pushServiceIndex === -1) {
-      KlaviyoLog.log('Adding KlaviyoPushService to manifest');
-      application.service.push({
-        $: {
-          'android:name': 'com.klaviyo.pushFcm.KlaviyoPushService',
-          'android:exported': 'false'
-        },
-        'intent-filter': [{
-          action: [{
-            $: {
-              'android:name': 'com.google.firebase.MESSAGING_EVENT'
-            }
-          }]
-        }]
-      });
-    }
-
     return config;
   });
 };


### PR DESCRIPTION
Starting with the release of klaviyo-android-sdk version 3.4.0, we'll be adding this to the SDK so that our 'merged manifest' will be able to add this instead of our Expo plugin doing it. 

Going to hold off on merging this one until I can test with the fully released SDK, but wanted to get 👁️ 👁️  before taking a few PTO days.