### PR TITLE
CHNL-23415: Add disclaimer about federated apple dev accounts + update example app for EAS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ The plugin is designed to work with the [klaviyo-react-native-sdk](https://githu
 - Minimum Deployment Target `13.0+`
 - Apple Push Notification Service (APNs) set up
 
+> **⚠️ Important Note for Federated Apple Developer Accounts:** If you're using a federated Apple Developer account, you'll need to provide an ASC API token with Admin access. While Expo supports federated accounts through ASC API tokens, the EAS CLI cannot directly log into federated accounts for credential management. See [Expo's documentation on federated accounts](https://docs.expo.dev/app-signing/apple-developer-program-roles-and-permissions/#federated-apple-developer-accounts) for more details.
+
 ## Installation
 
 1. Install the plugin in your Expo project. You need both `klaviyo-react-native-sdk` and `klaviyo-expo-plugin` for full functionality:

--- a/example/app.json
+++ b/example/app.json
@@ -59,6 +59,28 @@
     },
     "assetBundlePatterns": [
       "**/*"
-    ]
+    ],
+    "extra": {
+      "router": {},
+      "eas": {
+        "projectId": "1c04d6a2-82fa-477d-8ade-a79321cbd0b1",
+        "build": {
+          "experimental": {
+            "ios": {
+              "appExtensions": [
+                {
+                  "targetName": "KlaviyoNotificationServiceExtension",
+                  "bundleIdentifier": "com.klaviyo.expoexample.KlaviyoNotificationServiceExtension",
+                  "entitlements": {
+                    "com.apple.security.application-groups": ["group.com.klaviyo.expoexample.KlaviyoNotificationServiceExtension.shared"]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "owner": "klaviyo"
   }
 }


### PR DESCRIPTION
https://klaviyo.atlassian.net/browse/CHNL-23415

As suggested in https://github.com/klaviyo/klaviyo-expo-plugin/issues/37 -- adding an important disclaimer about federated apple developer accounts and linking to the Expo docs. Also adding a declaration in the `app.json` that should help EAS CLI know about the extension to generate the required credentials, as per the documentation [here](https://docs.expo.dev/build-reference/app-extensions/#managed-projects-experimental-support).