### PR TITLE
EAS Support: Fix metro config for local dev, remove project id

### DIFF
--- a/example/app.json
+++ b/example/app.json
@@ -63,7 +63,7 @@
     "extra": {
       "router": {},
       "eas": {
-        "projectId": "1c04d6a2-82fa-477d-8ade-a79321cbd0b1",
+        "projectId": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
         "build": {
           "experimental": {
             "ios": {

--- a/example/metro.config.js
+++ b/example/metro.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const fs = require('fs');
 const { getDefaultConfig } = require('expo/metro-config');
 
 const projectRoot = __dirname;
@@ -6,6 +7,9 @@ const localKlaviyoPath = path.resolve(projectRoot, '../../klaviyo-react-native-s
 
 const config = getDefaultConfig(projectRoot);
 
-config.watchFolders = [localKlaviyoPath];
+// Only add the local path to watchFolders if it exists (for local development)
+if (fs.existsSync(localKlaviyoPath)) {
+    config.watchFolders = [localKlaviyoPath];
+}
 
 module.exports = config;


### PR DESCRIPTION
Modifies example's metro config to support local development and replace projectId with placeholder