### PR TITLE
[CHNL-23504] Helper for robust plugin path resolution

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -33,15 +33,20 @@
       "version": "0.1.0-rc.1",
       "license": "ISC",
       "devDependencies": {
+        "@eslint/js": "^9.30.1",
         "@expo/config-plugins": "^9.0.15",
         "@types/glob": "^8.1.0",
         "@types/jest": "^29.5.0",
         "@types/node": "^20.0.0",
         "@types/xml2js": "^0.4.14",
+        "eslint": "^9.30.1",
+        "globals": "^16.3.0",
         "jest": "^29.5.0",
+        "prettier": "^3.6.2",
         "tmp": "^0.2.3",
         "ts-jest": "^29.1.0",
         "typescript": "^5.0.0",
+        "typescript-eslint": "^8.35.1",
         "xml2js": "^0.6.2"
       },
       "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "klaviyo-expo-plugin",
-  "version": "0.1.0-rc.3",
+  "version": "0.1.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "klaviyo-expo-plugin",
-      "version": "0.1.0-rc.3",
+      "version": "0.1.0-rc.1",
       "license": "ISC",
       "devDependencies": {
         "@eslint/js": "^9.30.1",

--- a/plugin/support/pluginResolver.ts
+++ b/plugin/support/pluginResolver.ts
@@ -1,0 +1,76 @@
+import * as path from 'path';
+import * as fs from 'fs';
+
+/**
+ * Generic function to find the plugin root directory
+ * Works with both npm install and local file references
+ */
+export function getPluginRoot(): string {
+  // Try multiple strategies to find the plugin root
+  const strategies = [
+    // Strategy 1: Try require.resolve (works for npm install)
+    () => {
+      try {
+        const pkgJsonPath = require.resolve('klaviyo-expo-plugin/package.json');
+        return path.dirname(pkgJsonPath);
+      } catch {
+        return null;
+      }
+    },
+    // Strategy 2: Look for package.json in common relative paths
+    () => {
+      const currentDir = __dirname;
+      const possiblePaths = [
+        path.join(currentDir, '..', '..', 'package.json'),
+        path.join(currentDir, '..', '..', '..', 'package.json'),
+        path.join(currentDir, '..', 'package.json'),
+      ];
+      
+      for (const pkgPath of possiblePaths) {
+        if (fs.existsSync(pkgPath)) {
+          const pkgContent = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+          if (pkgContent.name === 'klaviyo-expo-plugin') {
+            return path.dirname(pkgPath);
+          }
+        }
+      }
+      return null;
+    },
+    // Strategy 3: Search upward from current directory
+    () => {
+      let currentDir = __dirname;
+      const maxDepth = 10; // Prevent infinite loops
+      
+      for (let depth = 0; depth < maxDepth; depth++) {
+        const pkgPath = path.join(currentDir, 'package.json');
+        if (fs.existsSync(pkgPath)) {
+          try {
+            const pkgContent = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+            if (pkgContent.name === 'klaviyo-expo-plugin') {
+              return currentDir;
+            }
+          } catch {
+            // Continue searching if package.json is invalid
+          }
+        }
+        
+        const parentDir = path.dirname(currentDir);
+        if (parentDir === currentDir) {
+          break; // Reached root directory
+        }
+        currentDir = parentDir;
+      }
+      return null;
+    }
+  ];
+  
+  // Try each strategy until one works
+  for (const strategy of strategies) {
+    const result = strategy();
+    if (result) {
+      return result;
+    }
+  }
+  
+  throw new Error('Could not find klaviyo-expo-plugin root directory. Please ensure the plugin is properly installed.');
+} 

--- a/plugin/withKlaviyoIos.ts
+++ b/plugin/withKlaviyoIos.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { FileManager } from './support/fileManager';
 import { KlaviyoLog } from './support/logger';
+import { getPluginRoot } from './support/pluginResolver';
 
 const withKlaviyoIos: ConfigPlugin<KlaviyoPluginIosProps> = (config, props) => {
   KlaviyoLog.log('Starting iOS plugin configuration...');
@@ -32,9 +33,8 @@ const withKlaviyoPluginConfigurationPlist: ConfigPlugin = config => {
       throw new Error('Could not determine project name for iOS build');
     }
 
-    // Get the plugin's root directory using require.resolve to handle monorepo hoisting
-    const pkgJsonPath = require.resolve('klaviyo-expo-plugin/package.json');
-    const pluginRoot = path.dirname(pkgJsonPath);
+    // Get the plugin's root directory using a more generic approach
+    const pluginRoot = getPluginRoot();
     const srcPlistPath = path.join(pluginRoot, 'ios', 'klaviyo-plugin-configuration.plist');
     const destPlistPath = path.join(
       config.modRequest.platformProjectRoot,
@@ -298,9 +298,8 @@ const withKlaviyoNSE: ConfigPlugin<KlaviyoPluginIosProps> = (config) => {
       if (!FileManager.dirExists(nsePath)) {
         fs.mkdirSync(nsePath, { recursive: true });
       }
-      // Get the plugin's root directory using require.resolve to handle monorepo hoisting
-      const pkgJsonPath = require.resolve('klaviyo-expo-plugin/package.json');
-      const pluginRoot = path.dirname(pkgJsonPath);
+      // Get the plugin's root directory using a more generic approach
+      const pluginRoot = getPluginRoot();
       const sourceDir = path.join(pluginRoot, NSE_TARGET_NAME);
       for (const file of NSE_EXT_FILES) {
         try {


### PR DESCRIPTION
Our `require.resolve` works great for EAS but broke our local example app.

This PR adds a helper `pluginResolver.ts` that tries the remote first, then a few relative paths, then up 10 levels if it can't find the local copy of klaviyo expo plugin.