### PR TITLE
Set devTeam for both main app target and extension

### DIFF
--- a/plugin/withKlaviyoIos.ts
+++ b/plugin/withKlaviyoIos.ts
@@ -260,7 +260,10 @@ const withKlaviyoXcodeProject: ConfigPlugin<KlaviyoPluginIosProps> = (config, pr
     for (const key in configurations) {
       if (typeof configurations[key].buildSettings !== "undefined") {
         const buildSettingsObj = configurations[key].buildSettings;
-        
+        if (props.devTeam != undefined) {
+          buildSettingsObj.DEVELOPMENT_TEAM = props.devTeam;
+          xcodeProject.addTargetAttribute("DevelopmentTeam", props.devTeam)
+        }
         // Only apply NSE-specific settings to NSE target configurations
         if (configurations[key].buildSettings.PRODUCT_NAME == `"${NSE_TARGET_NAME}"`) {
           buildSettingsObj.CODE_SIGN_STYLE = props.codeSigningStyle;
@@ -268,17 +271,11 @@ const withKlaviyoXcodeProject: ConfigPlugin<KlaviyoPluginIosProps> = (config, pr
           buildSettingsObj.MARKETING_VERSION = props.marketingVersion;
           buildSettingsObj.SWIFT_VERSION = props.swiftVersion;
           buildSettingsObj.CODE_SIGN_ENTITLEMENTS = `${NSE_TARGET_NAME}/${NSE_TARGET_NAME}.entitlements`;
-          
           if (props.devTeam != undefined) {
-            buildSettingsObj.DEVELOPMENT_TEAM = props.devTeam;
+            xcodeProject.addTargetAttribute("DevelopmentTeam", props.devTeam, nseTarget);
           }
         }
       }
-    }
-    
-    // Add development team to the NSE target specifically
-    if (props.devTeam != undefined) {
-      xcodeProject.addTargetAttribute("DevelopmentTeam", props.devTeam, nseTarget);
     }
 
     return config;


### PR DESCRIPTION
We need to set the devTeam for both the main app target and the NSE. This fixes a bug in our plugin that only sets it in the NSE, so the main app target did not have access to the correct profile with the app groups capability set up on the Apple Developer Console. Verified badge count works (proof of App Group capability) with this change, without having to set anything in XCode.