### PR TITLE
fix: Add CFBundleDisplayName to KlaviyoNotificationServiceExtension

### DIFF
--- a/KlaviyoNotificationServiceExtension/KlaviyoNotificationServiceExtension-Info.plist
+++ b/KlaviyoNotificationServiceExtension/KlaviyoNotificationServiceExtension-Info.plist
@@ -21,6 +21,8 @@
 	<string>XPC!</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
+    <key>CFBundleDisplayName</key>
+	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>1.0</string>
 	<key>CFBundleDevelopmentRegion</key>


### PR DESCRIPTION
Added `CFBundleDisplayName` to KlaviyoNotificationServiceExtension-Info.plist because it was missing.