### PR TITLE
Remove swiftVersion configuration, add eas build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ npx expo install klaviyo-expo-plugin
             "codeSigningStyle": "Automatic",
             "projectVersion": "1",
             "marketingVersion": "1.0",
-            "swiftVersion": "5.0",
             "devTeam": undefined // your devTeam ID here
           }
         }
@@ -111,7 +110,6 @@ npx expo prebuild
 |`ios.codeSigningStyle`| string | optional | Declares management style for Code Signing Identity, Entitlements, and Provisioning Profile handled through XCode. Must be either "Manual" or "Automatic". Default: `"Automatic"`. Note: We highly recommend using the automatic signing style. If you select manual, you may need to go into your [developer.apple.com](https://developer.apple.com/) console and import the appropriate files and enable capabilities yourself.|
 |`ios.projectVersion`| string | optional | The internal build number for version. Default: `"1"`|
 |`ios.marketingVersion`| string | optional| The app version displayed in the App Store. Must be of the format "X.X" or "X.X.X". Default: `"1.0"`|
-|`ios.swiftVersion`| string | optional| The version of Swift Language used in the project. Must be one of 4.0, 4.2, 5.0, or 6.0. Default: `"5.0"`|
 |`ios.devTeam`| string | optional| The 10-digit alphanumeric Apple Development Team ID associated with the necessary signing capabilites, provisioning profile, etc. Format: "XXXXXXXXXX" Default: `undefined`|
 
 #### Debug mode

--- a/example/app.json
+++ b/example/app.json
@@ -48,7 +48,6 @@
             "codeSigningStyle": "Automatic",
             "projectVersion": "1",
             "marketingVersion": "1.0",
-            "swiftVersion": "5.0",
             "devTeam": "XXXXXXXXXX"
           }
         }

--- a/example/package.json
+++ b/example/package.json
@@ -10,7 +10,9 @@
     "test": "jest --watchAll",
     "reset-all": "cd .. && rm -rf node_modules package-lock.json && npm install && cd example && rm -rf node_modules package-lock.json && npm install",
     "clean-android": "cd .. && npm run build && cd example && rm -rf android && EXPO_DEBUG=true npx expo prebuild --clean --platform android && npx expo run:android",
-    "clean-ios": "cd .. && npm run build && cd example && rm -rf ios && EXPO_DEBUG=true npx expo prebuild --clean --platform ios && npx expo run:ios"
+    "clean-ios": "cd .. && npm run build && cd example && rm -rf ios && EXPO_DEBUG=true npx expo prebuild --clean --platform ios && npx expo run:ios",
+    "eas-ios-local": "rm -rf ios && npx expo prebuild --platform ios --clean && eas build --platform ios --local",
+    "eas-android-local": "rm -rf android && npx expo prebuild --platform android --clean && eas build --platform android --local"
   },
   "dependencies": {
     "@babel/runtime": "^7.24.0",

--- a/plugin/support/validateConfig.ts
+++ b/plugin/support/validateConfig.ts
@@ -73,16 +73,6 @@ export const validateIosConfig = (config: KlaviyoPluginProps['ios']) => {
     throw new KlaviyoConfigError('iOS marketingVersion must be in format "X.Y" or "X.Y.Z"');
   }
 
-  // Validate swiftVersion
-  if (config.swiftVersion) {
-    const allowedSwiftVersions = ['4.0', '4.2', '5.0', '6.0'];
-    if (!allowedSwiftVersions.includes(String(config.swiftVersion))) {
-      throw new KlaviyoConfigError(
-        `iOS swiftVersion must be one of: ${allowedSwiftVersions.join(', ')}`
-      );
-    }
-  }
-
   // Validate devTeam
   if (config.devTeam !== undefined) {
     if (typeof config.devTeam !== 'string' || !/^[A-Z0-9]{10}$/.test(config.devTeam)) {

--- a/plugin/types/index.ts
+++ b/plugin/types/index.ts
@@ -10,7 +10,6 @@ export interface KlaviyoPluginIosBaseProps  {
   codeSigningStyle: string;
   projectVersion: string;
   marketingVersion: string;
-  swiftVersion: string;
   devTeam?: string;
 }
 
@@ -31,7 +30,6 @@ export interface KlaviyoPluginIosProps extends KlaviyoPluginIosBaseProps {
   codeSigningStyle: string;
   projectVersion: string;
   marketingVersion: string;
-  swiftVersion: string;
   devTeam: string | undefined;
 }
 
@@ -52,7 +50,6 @@ const IOS_DEFAULTS: KlaviyoPluginIosProps = {
   codeSigningStyle: "Automatic",
   projectVersion: "1",
   marketingVersion: "1.0",
-  swiftVersion: "5.0",
   devTeam: undefined
 };
 

--- a/plugin/withKlaviyoIos.ts
+++ b/plugin/withKlaviyoIos.ts
@@ -249,20 +249,15 @@ const withKlaviyoXcodeProject: ConfigPlugin<KlaviyoPluginIosProps> = (config, pr
     for (const key in configurations) {
       if (typeof configurations[key].buildSettings !== "undefined") {
         const buildSettingsObj = configurations[key].buildSettings;
+        buildSettingsObj.CODE_SIGN_STYLE = props.codeSigningStyle;
+        buildSettingsObj.CURRENT_PROJECT_VERSION = props.projectVersion;
+        buildSettingsObj.MARKETING_VERSION = props.marketingVersion;
         if (props.devTeam != undefined) {
           buildSettingsObj.DEVELOPMENT_TEAM = props.devTeam;
-          xcodeProject.addTargetAttribute("DevelopmentTeam", props.devTeam)
         }
-        // Only apply NSE-specific settings to NSE target configurations
         if (configurations[key].buildSettings.PRODUCT_NAME == `"${NSE_TARGET_NAME}"`) {
-          buildSettingsObj.CODE_SIGN_STYLE = props.codeSigningStyle;
-          buildSettingsObj.CURRENT_PROJECT_VERSION = props.projectVersion;
-          buildSettingsObj.MARKETING_VERSION = props.marketingVersion;
-          buildSettingsObj.SWIFT_VERSION = props.swiftVersion;
+          buildSettingsObj.SWIFT_VERSION = "5.0";
           buildSettingsObj.CODE_SIGN_ENTITLEMENTS = `${NSE_TARGET_NAME}/${NSE_TARGET_NAME}.entitlements`;
-          if (props.devTeam != undefined) {
-            xcodeProject.addTargetAttribute("DevelopmentTeam", props.devTeam, nseTarget);
-          }
         }
       }
     }

--- a/tests/utils/testHelpers.ts
+++ b/tests/utils/testHelpers.ts
@@ -250,7 +250,6 @@ export interface MockIosPropsOptions {
   codeSigningStyle?: string;
   projectVersion?: string;
   marketingVersion?: string;
-  swiftVersion?: string;
   devTeam?: string;
 }
 
@@ -287,7 +286,6 @@ export const createMockIosProps = (options: MockIosPropsOptions = {}): any => ({
   codeSigningStyle: 'Automatic',
   projectVersion: '1',
   marketingVersion: '1.0',
-  swiftVersion: '5.0',
   devTeam: 'XXXXXXXXXX',
   ...options,
 }); 


### PR DESCRIPTION
- Added the `eas-ios-local` and `eas-android-local` build scripts to aid in local development
- Addresses bugs that came up while testing 0.1.0:
  - Removed unnecessary `swiftVersion` configuration as we are injecting our extension files that are always in Swift 5, and any other version would be incompatible anyways for this purpose and lead to other errors
  - Moved around the `buildSettingsObj` logic so it would correctly set the signing style and other associated values (dev team) for both expected targets, not just the extension

Verified these changes by including/excluding different args and expected builds were successfully validated by App Store Connect