### PR TITLE
Use dual delegates to process both Klaviyo handling and expo-notification events

### DIFF
--- a/ios/ExpoKlaviyo/KlaviyoAppDelegate.swift
+++ b/ios/ExpoKlaviyo/KlaviyoAppDelegate.swift
@@ -9,7 +9,7 @@ public final class KlaviyoAppDelegate: ExpoAppDelegateSubscriber, UNUserNotifica
         // Store the original delegate in order to call expo-notifications handlers
         let center = UNUserNotificationCenter.current()
         originalDelegate = center.delegate
-        // Allow Klaviyo intercept notifications
+        // Allow Klaviyo to intercept notifications
         center.delegate = self
         return true
     }


### PR DESCRIPTION
As a follow up to PR https://github.com/klaviyo/klaviyo-expo-plugin/pull/57 addressing Issue https://github.com/klaviyo/klaviyo-expo-plugin/issues/54 -- this adds in a form of double handling in the AppDelegate notification callbacks. 

It is a bit hacky (but isn't a lot of Expo!), but the `expo-notifications` listeners conflicting with other push providers is a known buggy area with Expo. This effectively ensures we handle both the the expected Klaviyo handling by setting the `center.delegate = self` but we also keep track of a separate `originalDelegate` instance where we can call the other `willPresent` and `didReceive` in order to trigger the expected `expo-notifications` listeners.

Verified this by:
1) Triggering a notification with the app foregrounded. Notification appeared and logged the `addNotificationReceivedListener` response:

https://github.com/user-attachments/assets/f40e7242-be90-4371-8b05-e5d500428b15

2) Triggering a notification with the app foregrounded and tapped on it. Notification appeared, logged the `addNotificationReceivedListener` response, logged the `addNotificationResponseReceivedListener` response, and called into the `KlaviyoSDK()`

https://github.com/user-attachments/assets/7093050e-3350-40a8-8bcc-fd41137bce48

3) Triggering a notification with the app backgrounded and tapped on it. Notification appeared, logged the `addNotificationResponseReceivedListener` response, and called into the `KlaviyoSDK()`

https://github.com/user-attachments/assets/4eda3843-96f4-4a42-be8f-377f6d65017d

