### PR TITLE
Make plugin options optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,24 @@ npx expo prebuild
 | `android.logLevel` | int | optional | Sets the logging level for the Klaviyo Android SDK. Default: `1` (DEBUG). Values: `0` (NONE), `1` (VERBOSE), `2` (DEBUG), `3` (INFO), `4` (WARNING), `5` (ERROR), `6` (ASSERT) |
 | `android.openTracking` | boolean | optional | Enables tracking when notifications are opened. Default: `true`. Note that this is considered to be a **dangerous** mod, as it directly modifies your MainActivity code. |
 | `android.notificationIconFilePath` | string | optional | Path to the notification icon file. Should be a white, transparent PNG. Default: none specified. Note that you should set this instead of `expo-notifications`, as they can conflict with each other. |
-| `android.notificationColor` | string | optional | Hex color for notification accent. Must be a valid hex value, e.g., `"#FF0000"` |
+| `android.notificationColor` | string | optional | Hex color for notification accent. Must be a valid hex value, e.g., `"#FF0000"` Default: `undefined` |
 | `ios.badgeAutoclearing` | boolean | optional | Enables automatic badge count clearing when app is opened. Default: `true` |
 |`ios.codeSigningStyle`| string | optional | Declares management style for Code Signing Identity, Entitlements, and Provisioning Profile handled through XCode. Must be either "Manual" or "Automatic". Default: `"Automatic"`. Note: We highly recommend using the automatic signing style. If you select manual, you may need to go into your [developer.apple.com](https://developer.apple.com/) console and import the appropriate files and enable capabilities yourself.|
 |`ios.projectVersion`| string | optional | The internal build number for version. Default: `"1"`|
 |`ios.marketingVersion`| string | optional| The app version displayed in the App Store. Must be of the format "X.X" or "X.X.X". Default: `"1.0"`|
 |`ios.devTeam`| string | optional| The 10-digit alphanumeric Apple Development Team ID associated with the necessary signing capabilites, provisioning profile, etc. Format: "XXXXXXXXXX" Default: `undefined`|
+
+Note: If you do not need to specify any of these for your project, it will use the defaults defined here. If you do not specify any of these props, you can add the plugin without additional arguments:
+```
+{
+  "expo": {
+    "plugins": [
+        //... other plugins
+        "klaviyo-expo-plugin"
+    ]
+  }
+}
+```
 
 #### Debug mode
 

--- a/plugin/types/index.ts
+++ b/plugin/types/index.ts
@@ -61,10 +61,10 @@ export const mergeIosProps = (props?: KlaviyoPluginIosBaseProps): KlaviyoPluginI
   return { ...IOS_DEFAULTS, ...(props ?? {}) };
 };
 
-export const mergeProps = (props: KlaviyoPluginProps): KlaviyoPluginPropsDefaultValues => {
+export const mergeProps = (props?: KlaviyoPluginProps): KlaviyoPluginPropsDefaultValues => {
   return {
-    android: mergeAndroidProps(props.android),
-    ios: mergeIosProps(props.ios)
+    android: mergeAndroidProps(props?.android),
+    ios: mergeIosProps(props?.ios)
   };
 };
 

--- a/plugin/withKlaviyo.ts
+++ b/plugin/withKlaviyo.ts
@@ -6,7 +6,7 @@ import { validateAndroidConfig, validateIosConfig } from './support/validateConf
 import * as path from 'path';
 import { KlaviyoLog } from './support/logger';
 
-const withKlaviyo: ConfigPlugin<KlaviyoPluginProps> = (config, props) => {
+const withKlaviyo: ConfigPlugin<KlaviyoPluginProps | undefined> = (config, props) => {
   KlaviyoLog.log('Running prebuild configuration');
 
   const mergedProps = mergeProps(props);


### PR DESCRIPTION
https://klaviyo.atlassian.net/browse/CHNL-25645

Addresses https://github.com/klaviyo/klaviyo-expo-plugin/issues/60

Verified this by running `npx expo prebuild` in our example app (in this repo) and providing no options `["klaviyo-expo-plugin"]`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allow using the plugin without providing props by making props optional in types and plugin entry; update README with defaults and a no-args usage example.
> 
> - **Plugin/Core**:
>   - Make `mergeProps` accept optional `KlaviyoPluginProps` and guard with optional chaining (`props?.android`, `props?.ios`).
>   - Update `withKlaviyo` to accept `KlaviyoPluginProps | undefined`.
> - **Docs**:
>   - Add note and example showing how to add `"klaviyo-expo-plugin"` with no options.
>   - Document default for `android.notificationColor` as `undefined`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a962f4da0d45d4d6f69fb62bbf02758a6f066ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->