### PR TITLE
chore: add nix flake and development tooling setup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+dotenv_if_exists .env
+
+if has nix; then
+  use flake
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ yarn-error.*
 # Klaviyo
 google-services.json 
 GoogleService-Info.plist
+
+# Nix
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1763622513,
+        "narHash": "sha256-1jQnuyu82FpiSxowrF/iFK6Toh9BYprfDqfs4BB+19M=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c58bc7f5459328e4afac201c5c4feb7c818d604b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,38 @@
+{
+  description = "Klaviyo Expo Plugin";
+  inputs = {
+    nixpkgs = {
+      url = "github:NixOS/nixpkgs/nixos-25.05";
+    };
+    utils = {
+      url = "github:numtide/flake-utils";
+    };
+  };
+  outputs =
+    {
+      nixpkgs,
+      utils,
+      ...
+    }:
+    utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            nodejs_24
+            lefthook
+            nixfmt-rfc-style
+          ];
+
+          shellHook = ''
+            if [ -f lefthook.yml ] && [ ! -f .git/hooks/pre-commit ]; then
+                lefthook install
+            fi
+          '';
+        };
+      }
+    );
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,7 @@
+pre-commit:
+  parallel: true
+  commands:
+    lint-nix:
+      glob: "*.nix"
+      run: nixfmt {staged_files}
+      stage_fixed: true


### PR DESCRIPTION
## Summary

This PR sets up Nix flake-based development environment tooling for the project.

### Changes
- Add Nix flake configuration with Node.js 24, lefthook, and nixfmt-rfc-style
- Configure direnv for automatic environment loading via `.envrc`
- Add lefthook for pre-commit hooks with Nix file formatting
- Update `.gitignore` to exclude `.direnv/` directory

### Benefits
- Reproducible development environment across machines
- Automatic environment activation when entering the project directory
- Consistent Nix code formatting via pre-commit hooks

### Usage
After this PR is merged, developers can:
1. Install Nix and direnv if not already installed
2. Run `direnv allow` to activate the development environment
3. The environment will automatically load Node.js 24, lefthook, and nixfmt