### PR TITLE
chore: Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Description
+<!-- Provide a brief description of the changes in this PR -->
+
+## Type of Change
+<!-- Mark the relevant option with an "x" -->
+- [ ] Bug fix (fix)
+- [ ] New feature (feat)
+- [ ] Code refactor (refactor)
+- [ ] Documentation update (docs)
+- [ ] Test update (test)
+- [ ] Tooling change (chore)
+
+## Related Issue
+<!-- Link to the related issue if applicable -->
+Fixes #
+
+## Testing
+<!-- Describe how you tested these changes -->
+- [ ] Tested with the example app
+- [ ] Verified on iOS
+- [ ] Verified on Android
+- [ ] Linters passing
+- [ ] Tests passing
+
+## Checklist
+- [ ] My code follows the conventional commits specification
+- [ ] I have updated the documentation accordingly
+- [ ] My changes generate no new warnings
+- [ ] I have kept this PR focused on a single change


### PR DESCRIPTION
## Description
Add a pull request template to guide contributors when opening PRs. The template aligns with the conventional commits specification and the contributing guidelines.

## Type of Change
- [x] Tooling change (chore)

## Testing
- [x] Verified the template file is created correctly

## Checklist
- [x] My code follows the conventional commits specification
- [x] I have kept this PR focused on a single change

🤖 Generated with [Claude Code](https://claude.com/claude-code)