### PR TITLE
ci: add publish-sdk workflow to publish to npm on release

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -6,10 +6,9 @@ on:
 
 jobs:
   publish-sdk:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
-      packages: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -1,0 +1,31 @@
+name: Publish SDK to NPM
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-sdk:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare
+        run: npm run prepare
+
+      - uses: JS-DevTools/npm-publish@v3
+        with:
+          token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description
Adds a GitHub Actions workflow that automatically publishes the package to npm when a GitHub release is published. Mirrors the pattern used in the RN SDK (`klaviyo-react-native-sdk`).

The workflow:
- Triggers on `release: [published]`
- Checks out the repo, sets up Node from `.nvmrc`, installs dependencies with `npm ci`
- Runs `npm run prepare` (clean + build)
- Publishes to npm using the `NPM_TOKEN` repository secret

## Type of Change
- [x] Tooling change (chore)

## Related Issue
https://linear.app/klaviyo/issue/MAGE-334/expo-or-add-publish-sdk-github-action

## Testing
- [x] Linters passing
- [x] Tests passing

## Checklist
- [x] My code follows the conventional commits specification
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have kept this PR focused on a single change