### PR TITLE
chore(example/ios): add logging for content-available

### DIFF
--- a/example/app/_layout.tsx
+++ b/example/app/_layout.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { StyleSheet, Platform} from 'react-native';
+import { StyleSheet, Platform, Alert } from 'react-native';
 import * as Notifications from 'expo-notifications';
 import * as TaskManager from 'expo-task-manager';
 import { Tabs } from 'expo-router';
@@ -153,11 +153,14 @@ export default function AppLayout() {
 
       // Store the notification in the app's state
       if (isSilentPush) {
+        Alert.alert('Silent Push (Foreground)', 'content-available=1, no alert payload.');
         // Store the notification data globally
         global.lastBackgroundNotification = {
           ...notification.request.content.data,
           receivedAt: new Date().toISOString()
         };
+      } else if (aps?.contentAvailable === 1) {
+        Alert.alert('Standard Push + content-available (Foreground)', 'content-available=1 WITH alert payload.');
       }
     });
 

--- a/example/app/_layout.tsx
+++ b/example/app/_layout.tsx
@@ -23,14 +23,27 @@ TaskManager.defineTask(BACKGROUND_NOTIFICATION_TASK, async ({ data, error, execu
     return;
   }
 
-  // Store the notification data in global variable for later retrieval
   if (data) {
+    const notification = (data as any).notification;
+    const aps = notification?.data?.aps as Record<string, unknown> | undefined;
+    const isSilentPush = aps?.contentAvailable === 1 && aps?.alert == null;
+
+    if (isSilentPush) {
+      // True silent push — no visible notification was shown. Add any background
+      // processing logic here, e.g. prefetch content or sync state.
+      console.log('Background task: true silent push received (content-available=1, no alert)');
+    } else {
+      // Standard push with content-available — a visible notification was shown and
+      // iOS also woke the app for background fetch. Add any background processing
+      // logic here, e.g. cache media or update local data before the user taps.
+      console.log('Background task: standard push with content-available received (alert was shown)');
+    }
+
     const notificationData = {
       ...data,
       receivedAt: new Date().toISOString(),
       isBackground: true
     };
-    // Store in global variable
     global.lastBackgroundNotification = notificationData;
     console.log('Stored background notification:', notificationData);
   }
@@ -48,8 +61,11 @@ export const checkForBackgroundNotifications = () => {
 // Configure notification handler
 Notifications.setNotificationHandler({
   handleNotification: async (notification) => {
-    // Check for silent push by looking at content-available in APS payload
-    const isSilentPush = notification.request.content.data?.aps?.contentAvailable === 1;
+    // A push is only a true silent push if content-available=1 AND there is no visible
+    // alert content. A standard push can also carry content-available=1 to request a
+    // background fetch — that is NOT a silent push and should still show an alert.
+    const aps = notification.request.content.data?.aps as Record<string, unknown> | undefined;
+    const isSilentPush = aps?.contentAvailable === 1 && aps?.alert == null;
     
     console.log('Notification received:', {
       isSilentPush,
@@ -115,7 +131,8 @@ export default function AppLayout() {
     // Foreground notification listener
     console.log('Setting up foreground notification listener');
     const foregroundSubscription = Notifications.addNotificationReceivedListener(notification => {
-      const isSilentPush = notification.request.content.data?.aps?.contentAvailable === 1;
+      const aps = notification.request.content.data?.aps as Record<string, unknown> | undefined;
+      const isSilentPush = aps?.contentAvailable === 1 && aps?.alert == null;
       
       console.log('Received foreground notification:', JSON.stringify({
         actionIdentifier: 'foreground',

--- a/example/app/_layout.tsx
+++ b/example/app/_layout.tsx
@@ -25,7 +25,7 @@ TaskManager.defineTask(BACKGROUND_NOTIFICATION_TASK, async ({ data, error, execu
 
   if (data) {
     const notification = (data as any).notification;
-    const aps = notification?.data?.aps as Record<string, unknown> | undefined;
+    const aps = notification?.request?.content?.data?.aps as Record<string, unknown> | undefined;
     const isSilentPush = aps?.contentAvailable === 1 && aps?.alert == null;
 
     if (isSilentPush) {

--- a/example/app/push.tsx
+++ b/example/app/push.tsx
@@ -113,7 +113,8 @@ export default function PushScreen() {
 
     const content = notification.request?.content || notification;
     const data = content.data || {};
-    const isSilent = content.data?.aps?.contentAvailable === 1;
+    const aps = data?.aps as Record<string, unknown> | undefined;
+    const isSilent = aps?.contentAvailable === 1 && aps?.alert == null;
 
     // Helper function to safely stringify objects
     const safeStringify = (obj: any) => {


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Adds logging to differentiate between silent push and background processing standard push in the example app. 

Add foreground Alert dialogs to visually confirm silent push vs standard push with content-available, making it easier to verify behavior during testing                                                                             

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (fix)
- [ ] New feature (feat)
- [ ] Code refactor (refactor)
- [ ] Documentation update (docs)
- [ ] Test update (test)
- [x] Tooling change (chore)

## Related Issue
<!-- Link to the related issue if applicable -->
Fixes #

## Testing
<!-- Describe how you tested these changes -->
- [ ] Tested with the example app
- [ ] Verified on iOS
- [ ] Verified on Android
- [x] Linters passing
- [x] Tests passing

## Checklist
- [ ] My code follows the conventional commits specification
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] I have kept this PR focused on a single change
