### PR TITLE
docs: fix typo in validateConfig comment (duplicated → deprecated)

### DIFF
--- a/plugin/support/validateConfig.ts
+++ b/plugin/support/validateConfig.ts
@@ -63,7 +63,7 @@ export const validateAndroidConfig = (config: KlaviyoPluginProps['android'], pro
 export const validateIosConfig = (config: KlaviyoPluginProps['ios']) => {
   if (!config) return;
 
-  // Warn if deprecated version props are used (duplicated in 0.3.0; use Expo-level build numbers instead)
+  // Warn if deprecated version props are used (deprecated in 0.3.0; use Expo-level build numbers instead)
   const configWithExtras = config as unknown as Record<string, unknown>;
   if (configWithExtras.projectVersion != null || configWithExtras.marketingVersion != null) {
     console.warn(


### PR DESCRIPTION
## Description
fixing a small foolish typo (git blamed, twas me)

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (fix)
- [ ] New feature (feat)
- [ ] Code refactor (refactor)
- [ ] Documentation update (docs)
- [ ] Test update (test)
- [ ] Tooling change (chore)

## Related Issue
<!-- Link to the related issue if applicable -->
Fixes #

## Testing
<!-- Describe how you tested these changes -->
- [ ] Tested with the example app
- [ ] Verified on iOS
- [ ] Verified on Android
- [ ] Linters passing
- [ ] Tests passing

## Checklist
- [ ] My code follows the conventional commits specification
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] I have kept this PR focused on a single change
