### PR TITLE
ci: add CodeRabbit configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,25 +14,3 @@ reviews:
   tools:
     eslint:
       enabled: true
-
-  path_instructions:
-    - path: "**"
-      instructions: |
-        # Cursor Bugbot Configuration
-        
-        This file configures Cursor's Bugbot for this repository.
-        
-        ## Primary Guidance
-        
-        Please read and follow the guidelines in `AGENTS.md` at the root of this repository.
-        
-        ## Repository-Specific Context
-        
-        This is the Klaviyo Expo Config Plugin - enables Klaviyo SDK integration in Expo managed workflows.
-        
-        - Always check AGENTS.md for repo-specific patterns and conventions
-        - Follow Expo config plugin best practices outlined in AGENTS.md
-        - Respect TypeScript coding standards and plugin architecture patterns
-        - Ensure plugin modifications are idempotent and don't break on re-runs
-        - Test changes with the example app before committing
-        - Verify both iOS and Android modifications work correctly

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -7,7 +7,6 @@ reviews:
     - "!**/package-lock.json"
     - "!**/Pods/**"
     - "!**/*.xcodeproj/**"
-    - "!example/**"
   auto_review:
     drafts: false
     base_branches:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,17 @@
+reviews:
+  profile: assertive
+  path_filters:
+    - "!**/node_modules/**"
+    - "!**/build/**"
+    - "!**/lib/**"
+    - "!**/package-lock.json"
+    - "!**/Pods/**"
+    - "!**/*.xcodeproj/**"
+    - "!example/**"
+  auto_review:
+    drafts: false
+    base_branches:
+      - ".*"
+  tools:
+    eslint:
+      enabled: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,7 +6,6 @@ reviews:
     - "!**/lib/**"
     - "!**/package-lock.json"
     - "!**/Pods/**"
-    - "!**/*.xcodeproj/**"
   auto_review:
     drafts: false
     base_branches:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,3 +14,25 @@ reviews:
   tools:
     eslint:
       enabled: true
+
+  path_instructions:
+    - path: "**"
+      instructions: |
+        # Cursor Bugbot Configuration
+        
+        This file configures Cursor's Bugbot for this repository.
+        
+        ## Primary Guidance
+        
+        Please read and follow the guidelines in `AGENTS.md` at the root of this repository.
+        
+        ## Repository-Specific Context
+        
+        This is the Klaviyo Expo Config Plugin - enables Klaviyo SDK integration in Expo managed workflows.
+        
+        - Always check AGENTS.md for repo-specific patterns and conventions
+        - Follow Expo config plugin best practices outlined in AGENTS.md
+        - Respect TypeScript coding standards and plugin architecture patterns
+        - Ensure plugin modifications are idempotent and don't break on re-runs
+        - Test changes with the example app before committing
+        - Verify both iOS and Android modifications work correctly

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,3 +109,9 @@ The Android plugin (`withKlaviyoAndroid.ts`) modifies:
 - `AndroidManifest.xml` — push receivers, services, and permissions
 - `build.gradle` — SDK dependencies and configuration
 - Resources — notification icon drawable and color values
+
+## Code Review
+
+CodeRabbit is active on this repo and auto-reviews PRs. It reads this file as a code guidelines
+source. When performing code reviews, avoid re-surfacing findings CodeRabbit may have already flagged.
+If you notice patterns worth encoding as review guidance, suggest adding them to `.coderabbit.yaml`.


### PR DESCRIPTION
Mirrors klaviyo-swift-sdk#597 for this repo.

- Adds `.coderabbit.yaml` — `profile: assertive`, no draft auto-review, all base branches; `path_filters` exclude node_modules, build outputs, `package-lock.json`, CocoaPods/Xcode artifacts, and the `example/` app.
- `tools`: eslint (`eslint.config.mjs`).
- Adds a `Code Review` section to AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for reviewers about automated code review being active and how to avoid duplicate findings.

* **Chores**
  * Enabled automated code-review tooling with an assertive profile, configured exclusions and draft-PR opt-out, set it to cover all branches, and enabled ESLint-based checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->