### PR TITLE
fix(ios): forward APNs push token via Expo app-delegate subscriber

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ npx expo prebuild
 |`ios.geofencingEnabled`| boolean | optional | Enables geofencing/location tracking support. When `true`, injects the necessary dependencies to set up registering for geofencing on app launch. When `false`, sets the `KLAVIYO_INCLUDE_LOCATION` Podfile ENV var to exclude the KlaviyoLocation pod. See [Geofencing](#geofencing) below. Default: `false` (geofencing disabled)|
 |`ios.formsEnabled`| boolean | optional | Controls whether the full forms module (in-app forms rendering with WebView) is included on iOS. When `false`, sets the `KLAVIYO_INCLUDE_FORMS` Podfile ENV var to exclude the module. Default: `true`|
 |`ios.includeNotificationServiceExtension`| boolean | optional | Controls whether the Notification Service Extension (NSE) target is automatically set up. Set to `false` if you already have an NSE (e.g., from another SDK) to prevent conflicts — iOS only executes one NSE per app. Default: `true`|
-|`ios.automaticPushTokenForwarding`| boolean | optional | Forwards the APNs push token to Klaviyo automatically. Opt-in, because on iOS this relies on app-delegate swizzling. When `false`, call `Klaviyo.setPushToken(...)` yourself. Default: `false` |
+|`ios.automaticPushTokenForwarding`| boolean | optional | Forwards the APNs push token to Klaviyo automatically via the plugin's app-delegate integration. Opt-in on iOS to match the native SDK's default. When `false`, call `Klaviyo.setPushToken(...)` yourself. Default: `false` |
 
 > **⚠️ Important:** The two `android.automaticPush*` props require `klaviyo-react-native-sdk` version
 > **2.5.0 or higher**, which bundles the native Android SDK that reads them. On older versions the

--- a/ios/ExpoKlaviyo/KlaviyoAppDelegate.swift
+++ b/ios/ExpoKlaviyo/KlaviyoAppDelegate.swift
@@ -54,4 +54,19 @@ public final class KlaviyoAppDelegate: ExpoAppDelegateSubscriber, UNUserNotifica
             completionHandler([.list, .banner, .badge, .sound])
         }
     }
+
+    /// Forwards the APNs device token to Klaviyo, in place of KlaviyoSwift's app-delegate
+    /// swizzling which races with JS-driven SDK init in a config-plugin setup. Gated on the
+    /// `klaviyo_automatic_push_token_forwarding` Info.plist key the plugin injects from the
+    /// `automaticPushTokenForwarding` prop.
+    public func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        let forwardingEnabled = Bundle.main.object(
+            forInfoDictionaryKey: "klaviyo_automatic_push_token_forwarding"
+        ) as? Bool ?? false
+        guard forwardingEnabled else { return }
+        KlaviyoSDK().set(pushToken: deviceToken)
+    }
 }


### PR DESCRIPTION
## Summary

On iOS, `automaticPushTokenForwarding` relied on KlaviyoSwift's app-delegate swizzling to capture the APNs device token. In an Expo config-plugin setup that swizzle is installed only from `KlaviyoSDK.initialize(with:)`, which runs from JS after launch — so `didRegisterForRemoteNotificationsWithDeviceToken` can fire before the swizzle is installed and the token is silently missed.

This handles the callback directly in `KlaviyoAppDelegate` (already a registered `ExpoAppDelegateSubscriber`) and forwards the token via `KlaviyoSDK().set(pushToken:)`. Expo delivers the callback to every subscriber at build-time registration, so this path is deterministic and coexists with expo-notifications' own subscriber. Gated on the same `klaviyo_automatic_push_token_forwarding` Info.plist key the plugin injects from the `automaticPushTokenForwarding` prop, so the opt-in stays authoritative.

## Why not the native swizzle

- The swizzle installs at JS-driven `initialize()` time; the APNs callback (triggered by expo-notifications' `getDevicePushTokenAsync` → `registerForRemoteNotifications()`) can beat it. expo-notifications receives the token because its subscriber is compiled in; Klaviyo's swizzle is not yet installed.
- The subscriber is the same mechanism expo-notifications itself uses, so no runtime swizzling fights Expo's `ExpoAppDelegate` forwarding.

## Known limitations / notes

- **Init ordering (unchanged SDK contract):** a token set while the SDK is fully uninitialized is dropped with a `"SDK must be initialized before usage."` warning, not buffered. `pendingRequests` only buffers from the `.initializing` state onward. This change closes the swizzle-timing gap but does **not** remove the "initialize first" requirement.
- **Open tracking not made configurable here:** the equivalent for open tracking is blocked — `KlaviyoSDK().handle(notificationResponse:)` fuses the `Opened Push` event with deep-link/web-URL routing, so it can't be gated without breaking deep links, and the native `klaviyo_automatic_push_open_tracking` proxy mishandles `willPresent` for Expo (it resolves before expo-notifications' async JS `setNotificationHandler`). Would need a KlaviyoSwift change to decouple open-event emission from routing.

## Docs

- Updated the `ios.automaticPushTokenForwarding` README row to drop the now-inaccurate "relies on app-delegate swizzling" description.
- No migration entry: `automaticPushTokenForwarding` is new in the unreleased 1.0.0, and `MIGRATION_GUIDE.md` already states "iOS: nothing to migrate."

## Testing

- [ ] Real device: enable push, trigger `getDevicePushTokenAsync()`, confirm the token registers on the Klaviyo profile **without** a manual `setPushToken()` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
