### PR TITLE
docs: correct automaticPushTokenForwarding default in README [MAGE-1114]

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ npx expo prebuild
 | `android.geofencingEnabled` | boolean | optional | Controls whether the full location module (with geofencing and permissions) is included. When `false`, only the lightweight location-core module is included (no location permissions). Sets the `klaviyoIncludeLocation` gradle property. Default: `false` |
 | `android.formsEnabled` | boolean | optional | Controls whether the full forms module (in-app forms rendering with WebView) is included. When `false`, only the lightweight forms-core module is included. Sets the `klaviyoIncludeForms` gradle property. Default: `true` |
 | `android.automaticPushOpenTracking` | boolean | optional | Tracks notification opens automatically. Set to `false` to opt out and call `Klaviyo.handlePush(intent)` yourself. Default: `true` |
-| `android.automaticPushTokenForwarding` | boolean | optional | Forwards the FCM push token to Klaviyo automatically. Set to `false` to opt out and call `Klaviyo.setPushToken(...)` yourself. Default: `true` |
+| `android.automaticPushTokenForwarding` | boolean | optional | Forwards the FCM push token to Klaviyo. Leaving this unset keeps the native SDK's default (forwards a token only when FCM delivers one); set to `true` to additionally fetch the token at init/foreground, or `false` to disable forwarding entirely. Default: unset |
 | `ios.badgeAutoclearing` | boolean | optional | Enables automatic badge count clearing when app is opened. Default: `true` |
 |`ios.codeSigningStyle`| string | optional | Declares management style for Code Signing Identity, Entitlements, and Provisioning Profile handled through XCode. Must be either "Manual" or "Automatic". Default: `"Automatic"`. Note: We highly recommend using the automatic signing style. If you select manual, you may need to go into your [developer.apple.com](https://developer.apple.com/) console and import the appropriate files and enable capabilities yourself.|
 |`ios.devTeam`| string | optional| The 10-digit alphanumeric Apple Development Team ID associated with the necessary signing capabilities, provisioning profile, etc. Format: "XXXXXXXXXX" Default: `undefined`|
@@ -132,6 +132,11 @@ npx expo prebuild
 > ```bash
 > npm install klaviyo-react-native-sdk@^2.5.0
 > ```
+
+**Note:** unlike `automaticPushOpenTracking`, this plugin does not inject a default value for
+`automaticPushTokenForwarding` — omitting it leaves the manifest flag unset, which forwards a token
+reactively (whenever FCM delivers one) but does not fetch proactively at startup. Set this prop to
+`true` if you want the SDK to also fetch the token at initialize/foreground.
 
 iOS push opens are tracked automatically and need no configuration, which is why there is no
 `ios.automaticPushOpenTracking` prop.


### PR DESCRIPTION
## Description

`android.automaticPushTokenForwarding` was documented as `Default: true`, but `withKlaviyoAndroid.ts` never actually injects `true` — it only writes the manifest key on explicit `false`; otherwise the key is omitted and the native SDK's default applies. That native default is now unset (reactive-only forwarding) rather than `true`, so the documented default no longer matched either the plugin's code or the resulting native behavior. Corrects the prop table and adds a clarifying note. No code changes.

## Type of Change

- [x] Documentation update (docs)

## Related Issue

MAGE-1114

## Testing

- [ ] Tested with the example app
- [ ] Verified on iOS
- [ ] Verified on Android
- [x] Linters passing
- [ ] Tests passing

Docs only — reviewed rendered Markdown for the changed sections.

## Checklist

- [x] My code follows the conventional commits specification
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have kept this PR focused on a single change

Note: whether `automaticPushTokenForwarding` should get a hardcoded plugin default of `true` (mirroring `automaticPushOpenTracking`'s `ANDROID_DEFAULTS` entry) is an open product decision tracked in MAGE-1114, not addressed here — this PR only corrects existing documentation.

Related: native Android SDK PR https://github.com/klaviyo/klaviyo-android-sdk/pull/536

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Android push-token forwarding behavior.
  * Documented the default unset state, reactive native SDK forwarding, proactive token fetching, and how to disable forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->